### PR TITLE
Set up outside proxy server for google places requests

### DIFF
--- a/app/controllers/GlobeViewCtrl.js
+++ b/app/controllers/GlobeViewCtrl.js
@@ -7,9 +7,12 @@ app.controller("GlobeViewCtrl", function($scope, $http, $sce, $timeout,GoogleMap
 
 	
 
-	var globeInput = $( "#globe-input" );
+	s.GooglePlacesRequest = (inputValue) => {
+		console.log(inputValue);
+		GoogleMapsFactory.GoogleMapsRequest(inputValue);		
+	};
 
-	GoogleMapsFactory.GoogleMapsRequest();
+	// GoogleMapsFactory.GoogleMapsRequest();
 
 		// console.log("I am active");
   //   navigator.geolocation.getCurrentPosition((location) => {

--- a/app/controllers/HomeCtrl.js
+++ b/app/controllers/HomeCtrl.js
@@ -5,8 +5,8 @@ console.log("HomeCtrl.js is connected");
 app.controller("HomeCtrl", function($scope, AuthUserFactory, $sce, GoogleMapsConfig) {
 	let s = $scope;
 
-	s.googleMapsUrl = 		$sce.trustAsResourceUrl(GoogleMapsConfig.googleMapsUrl);
-	s.googleLibraryPlaces = 	$sce.trustAsResourceUrl(GoogleMapsConfig.googleLibraryPlaces);
+	// s.googleMapsUrl = 		$sce.trustAsResourceUrl(GoogleMapsConfig.googleMapsUrl);
+	// s.googleLibraryPlaces = 	$sce.trustAsResourceUrl(GoogleMapsConfig.googleLibraryPlaces);
 	
 
 	console.log("HomeCtrl.js is working");

--- a/app/factories/GoogleMapsFactory.js
+++ b/app/factories/GoogleMapsFactory.js
@@ -4,8 +4,19 @@ console.log("GoogleMapsFactory.js is connected");
 
 app.factory("GoogleMapsFactory", function($http, $sce, GoogleMapsConfig) {
 
-	let GoogleMapsRequest = () => {
-		$http.get($sce.trustAsResourceUrl(GoogleMapsConfig.googleMapsUrl)).then(
+
+
+
+	//When passing in a param as the userInput, act as though 'https://maps.googleapis.com/maps/api/'
+	//is the base of the request, and format your userInput to match the string after this. 
+	//I have created a proxy server outside this repo to act as the middleman to gain access
+	//to this API. 
+	//I am using Heroku as the middleman to get the request I want. 
+
+	//Thanks to Blaise Roberts --> https://github.com/BlaiseRoberts/proxy-server
+
+	let GoogleMapsRequest = (userInput) => {
+		$http.get(`https://my-pretentious-cup.herokuapp.com/api/googleMaps/place/autocomplete/json?input=${userInput}&types=geocode&key=AIzaSyCBar6MbuEXMh-gwhp26Mncgg0Tk-HlsJM`).then(
 				(response) => console.log(response.data)
 			);
 	};

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
 	<title>My Pretentious Cup</title>
 	<meta charset="utf-8">
-	<!-- <script src="https://maps.google.com/maps/api/js?libraries=placeses,visualization,drawing,geometry,places"></script> -->
+	
 	<link rel="stylesheet" href="lib/node_modules/bootstrap/dist/css/bootstrap.min.css">
 	<link rel="stylesheet" type="text/css" href="css/main.css">
 </head>
@@ -17,7 +17,6 @@
 
 
 
-<!-- <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC_Jm47nxI21WmJLymRAb2zjWRl5BecQ5s"></script> -->
 
 <!--ALL PACKAGES-->
 <script type="text/javascript" src="lib/node_modules/jquery/dist/jquery.min.js"></script>
@@ -29,9 +28,7 @@
 <script type="text/javascript" src="lib/node_modules/angular-ui-router/release/angular-ui-router.min.js"></script>
 <script type="text/javascript" src="lib/node_modules/angular-animate/angular-animate.min.js"></script>
 <script type="text/javascript" src="lib/node_modules/angular-aria/angular-aria.min.js"></script>
-<!-- <script type="text/javascript" src="lib/node_modules/ngmap/build/scripts/ng-map.min.js"></script>
- -->
- <script type="text/javascript" src="lib/node_modules/d3/build/d3.min.js"></script>
+<script type="text/javascript" src="lib/node_modules/d3/build/d3.min.js"></script>
 
 <!-- MODULES -->
 <script type="text/javascript" src="app/modules/d3Module.js"></script>

--- a/partials/GlobeView.html
+++ b/partials/GlobeView.html
@@ -2,9 +2,10 @@
 
 <div class="row">
 	<div class="col-xs-4">	
-    <input id="globe-input" type="text"
-        placeholder="Enter a location">
+    <input ng-model="globeInput" ng-keyup="GooglePlacesRequest(globeInput)" id="globe-input" type="text"
+    placeholder="Enter a location">
 	</div>
+	<button type="button" class="btn btn-primary btn-block">Search API</button> 
 </div>
 
 <div style="width: 100%; height: 500px" id="map"></div>

--- a/partials/Home.html
+++ b/partials/Home.html
@@ -12,7 +12,7 @@
 	</div>
 </div>
 
-<script type="text/javascript" ng-src="s.googleMapsUrl"
+<!-- <script type="text/javascript" ng-src="s.googleMapsUrl"
 	async defer></script>
 <script type="text/javascript" ng-src="s.googleLibraryPlaces"
-	async defer></script>
+	async defer></script> -->


### PR DESCRIPTION
Set up an outside repo to act as a proxy for Google Maps requests. 

Google maps api does not allow localhost: requests, so an outside source was needed. You will not find these files within this repo. 
I created a proxy server pointing up to google maps api base, and then setting up a Heroku account to serve as a middleman for my requests. 

I can now point requests up to heroku, and they will make the request for me, and send back my data. 

I have the calls as a $hhtp.get() request instead of a <script src= "myApiRequest"> on the index.html or a partial.